### PR TITLE
Add documentation for Scheduler.start()

### DIFF
--- a/docs/reference/scheduler.md
+++ b/docs/reference/scheduler.md
@@ -7,6 +7,9 @@ Provides a class that schedules events after a certain amount of time.
 <span class="docs">Creates a scheduler. All events are canceled when the context manager exits.</span>
 
 ## Scheduler
+<code>**def start**() -> None</code><br>
+<span class="docs">Begins executing scheduled events. Call this after `schedule()` or `repeat()`.</span>
+
 <code>**def schedule**(function: Callable, delay: float, \*args) -> int</code><br>
 <span class="docs">Schedules an asynchronous function call after `delay` seconds. Returns a handle that can be passed to `remove()`.</span>
 


### PR DESCRIPTION
Add missing documentation on launch function for Scheduler.

~~
Sorry if am having a 2am moment here - is this the right way to fire up the scheduler?
